### PR TITLE
Fix for JS bundling problem

### DIFF
--- a/dist/ng-input-currency.js
+++ b/dist/ng-input-currency.js
@@ -108,4 +108,4 @@ angular.module('ngInputCurrency').directive('ngInputCurrency', ['$locale','$filt
   };
 }]);
 
-},{}]},{},[1])
+},{}]},{},[1]);


### PR DESCRIPTION
First of all, great tool thank you for this! :)

Would just like to give a suggestion if it is possible.

Me and some of my co workers are using this project and we all noticed that whenever we include this library in a bundling script, our program crashes. Later I found out that it is caused by not having a semi colon at the end of the script. Apparently, there is no problem on my workflow if this library is bundled at the very bottom of the script but if this is in between two different scripts all the scripts below this library will failed to load. Having said this, we constantly making sure that this library will be bundled last by reordering our bower.json.

I am not sure if including a terminating semi colon would have a negative/unprecedented effect on us users, but please let me know if this is ok or what should I do about my current situation.

Thank you!